### PR TITLE
Add SMS test feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,16 @@
       box-sizing: border-box;
     }
 
+    input.text-input {
+      width: 100%;
+      margin: 0 auto 20px auto;
+      display: block;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      padding: 10px;
+      box-sizing: border-box;
+    }
+
     table {
       border-collapse: collapse;
       width: 100%;
@@ -86,6 +96,8 @@
 <body>
   <div class="container">
     <button type="button" class="btn" id="save">保存</button>
+    <input type="text" id="testPhone" class="text-input" placeholder="测试手机号，多个用逗号分隔" />
+    <button type="button" class="btn" id="sendTestSMS">发送测试短信</button>
     <p id="progress"></p>
     <textarea id="config" placeholder="每行格式：域名[:端口]|手机号1,手机号2"></textarea>
     <div>
@@ -252,8 +264,29 @@
       })
     }
 
+    const sendTestSMS = () => {
+      const phoneStr = document.getElementById('testPhone').value.trim()
+      if (!phoneStr) {
+        alert('请输入测试手机号')
+        return
+      }
+      const phones = phoneStr.split(',').map(p => p.trim()).filter(p => p)
+      fetch('/api/testSMS', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phones })
+      }).then(response => response.json()).then(json => {
+        if (json.code === 1) {
+          alert('发送成功')
+        } else {
+          alert('发送失败:' + json.msg)
+        }
+      })
+    }
+
     window.onload = function () {
       document.getElementById('save').onclick = setConfig
+      document.getElementById('sendTestSMS').onclick = sendTestSMS
       getConfig()
     }
   </script>

--- a/main.js
+++ b/main.js
@@ -188,6 +188,19 @@ fastify.after(() => {
       return { code: -1, msg: err.message }
     }
   })
+
+  fastify.post('/api/testSMS', async (req, reply) => {
+    const { phones } = req.body
+    if (!Array.isArray(phones) || phones.length === 0) {
+      return { code: -2, msg: '手机号不能为空' }
+    }
+    try {
+      const result = await sendSMS(phones, { host: 'test', day: 0 })
+      return { code: 1, result }
+    } catch (err) {
+      return { code: -1, msg: err.message }
+    }
+  })
 })
 
 schedule.scheduleJob('0 0 * * *', async function () {


### PR DESCRIPTION
## Summary
- add phone input and button in web UI to send test SMS
- implement `sendTestSMS` front-end function
- expose `/api/testSMS` endpoint in backend

## Testing
- `node -c main.js`
- `npm run start` *(fails: Cannot find module 'fastify')*

------
https://chatgpt.com/codex/tasks/task_e_6856984817c0832fa39be091888b5ff6