### PR TITLE
Replace Basic Auth with login page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # ===== 鉴权（必填，否则拒绝启动） =====
-# Basic Auth 的用户名与密码，请使用强口令
+# 登录页的用户名与密码，请使用强口令
 AUTH_USERNAME=admin
 AUTH_PASSWORD=change-me
+# 可选：登录会话签名密钥；不设置时默认复用 AUTH_PASSWORD
+AUTH_SESSION_SECRET=
+# 可选：登录会话有效期（秒），默认 86400
+AUTH_SESSION_TTL_SECONDS=86400
+# 可选：HTTPS 部署时建议设置为 true，让浏览器仅通过 HTTPS 发送登录 cookie
+AUTH_COOKIE_SECURE=false
 
 # ===== 服务监听（可选） =====
 # 监听端口，默认 9000

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,10 @@
 
 ### Node.js 后端 (`main.js`)
 - 使用 **Fastify** 作为 HTTP 服务器
-- 提供 Basic Auth 保护的接口：
+- 提供登录页和签名会话 Cookie 保护的页面与接口：
+  - `/login` – 返回 `login.html`
+  - `/api/login` – 校验用户名密码并下发登录会话 Cookie
+  - `/api/logout` – 清除登录会话 Cookie
   - `/` – 返回 `index.html`
   - `/api/config` – 获取或更新 `config.txt` 内容
   - `/api/checkerSSLCertificate` – 查询指定域名和端口的证书信息
@@ -25,7 +28,8 @@
 - 详见 `README.md` 的「环境变量一览」与 `.env.example`
 
 ### 健壮性设计
-- **凭证比较**：Basic Auth 使用 `crypto.timingSafeEqual` 恒定时间比较，规避时序侧信道
+- **凭证与会话比较**：登录凭证与会话签名使用 `crypto.timingSafeEqual` 恒定时间比较，规避时序侧信道
+- **会话保护**：登录成功后下发 httpOnly、SameSite=Lax 的签名 Cookie，过期或签名非法时拒绝访问受保护接口
 - **缓存**：内存优先 + 临时文件 `rename` 原子落盘，合并并发写入，规避读改写丢失与文件损坏
 - **输入校验**：API 对 host/port 做合法性校验
 - **优雅退出**：`SIGINT`/`SIGTERM` 时取消定时任务、落盘缓存、关闭服务器
@@ -34,20 +38,22 @@
 - 文本格式，每行 `域名[:端口]|手机号1,手机号2`
 - 支持使用 `//` 添加注释
 
-### 前端页面 (`index.html`)
-- 使用 Basic Auth 保护的简易 HTML 页面
+### 前端页面 (`login.html`、`index.html`)
+- `login.html` 提供普通登录表单
+- `index.html` 使用登录会话保护，并提供退出登录入口
 - 可在文本框中编辑 `config.txt`，并查看当前证书状态表格
 - 通过 `fetch` 调用后台接口
 
 ## 运行流程
-1. 用户通过 Basic Auth 访问 `index.html`
-2. 前端调用 `/api/config` 读取配置并填充表格
-3. 每个域名通过 `/api/checkerSSLCertificate` 获取证书有效信息
-4. 后端定时任务每日检查所有域名，在证书即将过期时发送短信通知
+1. 用户访问 `/login` 并提交用户名密码
+2. 后端校验成功后写入登录会话 Cookie，浏览器进入 `index.html`
+3. 前端调用 `/api/config` 读取配置并填充表格
+4. 每个域名通过 `/api/checkerSSLCertificate` 获取证书有效信息
+5. 后端定时任务每日检查所有域名，在证书即将过期时发送短信通知
 
 ## 依赖
 - Node.js
-- `fastify`、`@fastify/basic-auth`
+- `fastify`
 - `node-schedule`
 - `axios`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 1. 以简单的 js 脚本在 node.js 平台实现程序，利用现成的[node-schedule](https://github.com/node-schedule/node-schedule)库实现定时任务。
 2. 通过`axios`调用第三方接口实现短信发送，参数为`手机号数组`+`域名`+`即将过期天数/-过期天数`。
-3. 通过 HTML + JS 实现通知列表的可视化维护，通过 Basic Auth 进行身份认证。需要一个 Web 服务器实现服务器端向客户端输出 HTML 数据和 HTTP API，选择方便快捷的`fastify`及其插件`fastify-basic-auth`。
+3. 通过 HTML + JS 实现通知列表的可视化维护，通过登录页和签名会话 Cookie 进行身份认证。需要一个 Web 服务器实现服务器端向客户端输出 HTML 数据和 HTTP API，选择方便快捷的`fastify`。
 4. 通过 Node.js 的[https](https://nodejs.org/api/https.html)相关 API 实现对证书信息的获取。
 
 ## 实现
@@ -22,7 +22,7 @@
 安装可能用到的依赖：
 
 ```bash
-yarn add node-schedule axios fastify fastify-basic-auth
+yarn add node-schedule axios fastify
 ```
 
 获取某个域名的 SSL 证书信息：
@@ -91,8 +91,11 @@ node main.js   # 或 pnpm start
 
 | 变量 | 必填 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `AUTH_USERNAME` | ✅ | — | Basic Auth 用户名 |
-| `AUTH_PASSWORD` | ✅ | — | Basic Auth 密码（请用强口令） |
+| `AUTH_USERNAME` | ✅ | — | 登录用户名 |
+| `AUTH_PASSWORD` | ✅ | — | 登录密码（请用强口令） |
+| `AUTH_SESSION_SECRET` | | `AUTH_PASSWORD` | 登录会话签名密钥 |
+| `AUTH_SESSION_TTL_SECONDS` | | `86400` | 登录会话有效期（秒） |
+| `AUTH_COOKIE_SECURE` | | `false` | 是否为登录 Cookie 添加 `Secure` 标记；HTTPS 部署建议开启 |
 | `PORT` | | `9000` | 监听端口 |
 | `HOST` | | `0.0.0.0` | 监听地址（建议生产仅监听 `127.0.0.1` + 反向代理） |
 | `CHECK_CRON` | | `0 0 * * *` | 定时巡检 cron 表达式 |

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
     .header {
       text-align: center;
       margin-bottom: 40px;
+      position: relative;
     }
 
     .header h1 {
@@ -79,6 +80,12 @@
     .header p {
       color: #666;
       font-size: 1.1rem;
+    }
+
+    .header-actions {
+      position: absolute;
+      top: 0;
+      right: 0;
     }
 
     .control-panel {
@@ -149,6 +156,13 @@
 
     #sendTestSMS {
       background: linear-gradient(135deg, #f093fb, #f5576c);
+    }
+
+    #logout {
+      min-width: auto;
+      padding: 10px 16px;
+      font-size: 14px;
+      background: linear-gradient(135deg, #495057, #212529);
     }
 
     input.text-input {
@@ -379,6 +393,13 @@
         font-size: 2rem;
       }
 
+      .header-actions {
+        position: static;
+        display: flex;
+        justify-content: center;
+        margin-top: 16px;
+      }
+
       .button-group {
         flex-direction: column;
         align-items: stretch;
@@ -433,6 +454,9 @@
     <div class="header">
       <h1>SSL 证书监测</h1>
       <p>轻松监控您的SSL证书状态，及时获得过期提醒</p>
+      <div class="header-actions">
+        <button type="button" class="btn" id="logout">退出登录</button>
+      </div>
     </div>
 
     <div class="control-panel">
@@ -504,13 +528,28 @@
       return fmt;
     }
 
+    const SESSION_EXPIRED = 'SESSION_EXPIRED'
+
+    const apiFetch = (url, options = {}) => {
+      return fetch(url, {
+        credentials: 'same-origin',
+        ...options
+      }).then(response => {
+        if (response.status === 401) {
+          window.location.href = '/login'
+          throw new Error(SESSION_EXPIRED)
+        }
+        return response
+      })
+    }
+
     const checkerSSLCertificate = (host, port = 443) => {
       return new Promise((resolve, reject) => {
         if (!port || isNaN(parseFloat(port)) || !isFinite(port)) {
           reject(new Error('Invalid host or port'))
         }
 
-        fetch(`/api/checkerSSLCertificate?host=${host}&port=${port}`, {
+        apiFetch(`/api/checkerSSLCertificate?host=${encodeURIComponent(host)}&port=${encodeURIComponent(port)}`, {
           method: "GET",
           // mode: 'cors',
         }).then(response => response.json()).then(json => {
@@ -521,7 +560,7 @@
 
 
     const getConfig = () => {
-      fetch('/api/config', {
+      apiFetch('/api/config', {
         method: 'GET',
       }).then(response => response.json()).then(json => {
         if (json.code !== 1) {
@@ -605,6 +644,7 @@
               `
             }
           }).catch(err => {
+            if (err.message === SESSION_EXPIRED) return
             const tr = document.getElementById(rowId)
             tr.innerHTML = `
               <td>${host}${port && port !== '443' ? ':' + port : ''}</td>
@@ -614,6 +654,9 @@
             `
           }).finally(updateProgress)
         })
+      }).catch(err => {
+        if (err.message === SESSION_EXPIRED) return
+        alert('获取配置数据失败：网络错误')
       })
     }
     const setConfig = () => {
@@ -622,7 +665,7 @@
       saveBtn.textContent = '💫 保存中...'
       saveBtn.disabled = true
 
-      fetch("/api/config", {
+      apiFetch("/api/config", {
         method: "POST",
         headers: {
           'Content-Type': 'application/json'
@@ -642,6 +685,7 @@
           saveBtn.disabled = false
         }
       }).catch(err => {
+        if (err.message === SESSION_EXPIRED) return
         alert('保存失败：网络错误')
         saveBtn.textContent = originalText
         saveBtn.disabled = false
@@ -661,7 +705,7 @@
       smsBtn.disabled = true
 
       const phones = phoneStr.split(',').map(p => p.trim()).filter(p => p)
-      fetch('/api/testSMS', {
+      apiFetch('/api/testSMS', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phones })
@@ -678,15 +722,26 @@
           smsBtn.disabled = false
         }
       }).catch(err => {
+        if (err.message === SESSION_EXPIRED) return
         alert('发送失败：网络错误')
         smsBtn.textContent = originalText
         smsBtn.disabled = false
       })
     }
 
+    const logout = () => {
+      fetch('/api/logout', {
+        method: 'POST',
+        credentials: 'same-origin'
+      }).finally(() => {
+        window.location.href = '/login'
+      })
+    }
+
     window.onload = function () {
       document.getElementById('save').onclick = setConfig
       document.getElementById('sendTestSMS').onclick = sendTestSMS
+      document.getElementById('logout').onclick = logout
       getConfig()
     }
   </script>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>登录 - SSL 证书监测</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      color: #333;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+
+    .login-card {
+      width: min(100%, 420px);
+      padding: 40px;
+      border-radius: 20px;
+      background: rgba(255, 255, 255, 0.96);
+      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.14);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .login-card::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 4px;
+      background: linear-gradient(90deg, #667eea, #764ba2, #f093fb, #f5576c);
+    }
+
+    .brand {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    .brand h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 8px;
+    }
+
+    .brand p {
+      color: #666;
+      font-size: 1rem;
+    }
+
+    .field {
+      margin-bottom: 18px;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 8px;
+      color: #495057;
+      font-weight: 600;
+    }
+
+    input {
+      width: 100%;
+      height: 48px;
+      padding: 0 16px;
+      border: 2px solid #e1e5e9;
+      border-radius: 12px;
+      font-size: 16px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      background: #fff;
+    }
+
+    input:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    }
+
+    button {
+      width: 100%;
+      height: 48px;
+      margin-top: 8px;
+      border: none;
+      border-radius: 12px;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+      cursor: pointer;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      box-shadow: 0 8px 20px rgba(102, 126, 234, 0.28);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(102, 126, 234, 0.34);
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.7;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .error {
+      min-height: 22px;
+      margin-top: 16px;
+      color: #dc3545;
+      text-align: center;
+      font-weight: 600;
+    }
+
+    .error[hidden] {
+      display: block;
+      visibility: hidden;
+    }
+
+    @media (max-width: 480px) {
+      .login-card {
+        padding: 30px 22px;
+        border-radius: 16px;
+      }
+
+      .brand h1 {
+        font-size: 1.7rem;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <main class="login-card">
+    <div class="brand">
+      <h1>SSL 证书监测</h1>
+      <p>请登录后继续</p>
+    </div>
+
+    <form id="loginForm">
+      <div class="field">
+        <label for="username">用户名</label>
+        <input id="username" name="username" type="text" autocomplete="username" required autofocus>
+      </div>
+
+      <div class="field">
+        <label for="password">密码</label>
+        <input id="password" name="password" type="password" autocomplete="current-password" required>
+      </div>
+
+      <button id="loginButton" type="submit">登录</button>
+      <p id="error" class="error" role="alert" hidden>登录失败</p>
+    </form>
+  </main>
+
+  <script>
+    const form = document.getElementById('loginForm')
+    const button = document.getElementById('loginButton')
+    const error = document.getElementById('error')
+
+    form.addEventListener('submit', event => {
+      event.preventDefault()
+
+      error.hidden = true
+      button.disabled = true
+      button.textContent = '登录中...'
+
+      fetch('/api/login', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: document.getElementById('username').value,
+          password: document.getElementById('password').value
+        })
+      }).then(async response => {
+        const json = await response.json().catch(() => ({}))
+        if (!response.ok || json.code !== 1) {
+          throw new Error(json.msg || '登录失败')
+        }
+        window.location.href = '/'
+      }).catch(err => {
+        error.textContent = err.message || '登录失败'
+        error.hidden = false
+        button.disabled = false
+        button.textContent = '登录'
+      })
+    })
+  </script>
+</body>
+
+</html>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,11 @@ const schedule = require('node-schedule')
 // ===== 配置（全部来自环境变量，无硬编码凭证） =====
 const USERNAME = process.env.AUTH_USERNAME
 const PASSWORD = process.env.AUTH_PASSWORD
+const SESSION_SECRET = process.env.AUTH_SESSION_SECRET || PASSWORD
+const SESSION_TTL_SECONDS = process.env.AUTH_SESSION_TTL_SECONDS
+  ? parseInt(process.env.AUTH_SESSION_TTL_SECONDS, 10)
+  : 24 * 60 * 60
+const COOKIE_SECURE = process.env.AUTH_COOKIE_SECURE === 'true'
 const PORT = parseInt(process.env.PORT, 10) || 9000
 const HOST = process.env.HOST || '0.0.0.0'
 const CHECK_CRON = process.env.CHECK_CRON || '0 0 * * *' // 每天 0 点
@@ -23,8 +28,10 @@ const MAX_RETRIES = parseInt(process.env.MAX_RETRIES, 10) || 5
 const CACHE_FILE = path.join(__dirname, 'ssl_cache.json')
 const CONFIG_FILE = path.join(__dirname, 'config.txt')
 const INDEX_FILE = path.join(__dirname, 'index.html')
+const LOGIN_FILE = path.join(__dirname, 'login.html')
 const CACHE_EXPIRATION_SUCCESS = 5 * 60 * 1000 // 成功结果缓存 5 分钟
 const CACHE_EXPIRATION_ERROR = 1 * 60 * 1000 // 错误结果缓存 1 分钟
+const SESSION_COOKIE_NAME = 'ssl_checker_session'
 
 // ===== 启动前置校验：缺少鉴权凭证则拒绝启动（避免裸奔） =====
 if (!USERNAME || !PASSWORD) {
@@ -41,14 +48,111 @@ if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65535) {
   process.exit(1)
 }
 
+if (!Number.isInteger(SESSION_TTL_SECONDS) || SESSION_TTL_SECONDS <= 0) {
+  console.error(`[FATAL] 非法登录会话有效期: ${process.env.AUTH_SESSION_TTL_SECONDS}`)
+  process.exit(1)
+}
+
 // ===== 工具函数 =====
 
-// 恒定时间比较，避免 Basic Auth 凭证的时序侧信道泄露
+// 恒定时间比较，避免凭证与签名比较的时序侧信道泄露
 function safeEqual (a, b) {
   const bufA = Buffer.from(String(a))
   const bufB = Buffer.from(String(b))
   if (bufA.length !== bufB.length) return false
   return crypto.timingSafeEqual(bufA, bufB)
+}
+
+function parseCookies (req) {
+  const header = req.headers.cookie
+  if (!header) return {}
+
+  const cookies = {}
+  for (const part of header.split(';')) {
+    const index = part.indexOf('=')
+    if (index === -1) continue
+    const name = part.slice(0, index).trim()
+    const value = part.slice(index + 1).trim()
+    if (!name) continue
+    try {
+      cookies[name] = decodeURIComponent(value)
+    } catch (err) {
+      cookies[name] = value
+    }
+  }
+  return cookies
+}
+
+function serializeSessionCookie (value, maxAge) {
+  const parts = [
+    `${SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${maxAge}`
+  ]
+  if (COOKIE_SECURE) parts.push('Secure')
+  return parts.join('; ')
+}
+
+function signSessionPayload (payload) {
+  return crypto.createHmac('sha256', SESSION_SECRET).update(payload).digest('base64url')
+}
+
+function createSessionToken () {
+  const payload = Buffer.from(JSON.stringify({
+    u: USERNAME,
+    exp: Date.now() + SESSION_TTL_SECONDS * 1000,
+    nonce: crypto.randomBytes(16).toString('base64url')
+  }), 'utf8').toString('base64url')
+
+  return `${payload}.${signSessionPayload(payload)}`
+}
+
+function verifySessionToken (token) {
+  if (!token || typeof token !== 'string') return false
+
+  const [payload, signature] = token.split('.')
+  if (!payload || !signature || token.split('.').length !== 2) return false
+
+  const expectedSignature = signSessionPayload(payload)
+  if (!safeEqual(signature, expectedSignature)) return false
+
+  let data
+  try {
+    data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+  } catch (err) {
+    return false
+  }
+
+  return Boolean(
+    data &&
+    safeEqual(data.u, USERNAME) &&
+    Number.isFinite(data.exp) &&
+    data.exp > Date.now()
+  )
+}
+
+function isAuthenticated (req) {
+  const cookies = parseCookies(req)
+  return verifySessionToken(cookies[SESSION_COOKIE_NAME])
+}
+
+function requireAuth (req, reply, done) {
+  if (isAuthenticated(req)) return done()
+
+  reply.code(401).send({ code: -401, msg: '未登录或登录已过期' })
+}
+
+function sendHtmlFile (reply, filePath, errorMsg) {
+  try {
+    reply.type('text/html')
+    reply.header('Cache-Control', 'no-store')
+    return fs.readFileSync(filePath)
+  } catch (err) {
+    reply.code(500)
+    return { code: -1, msg: errorMsg }
+  }
 }
 
 // 校验并归一化端口
@@ -215,96 +319,102 @@ async function cachedCheckerSSLCertificate (host, port = 443) {
 }
 
 // ===== HTTP 服务 =====
-fastify.register(require('@fastify/basic-auth'), {
-  validate: (username, password, req, reply, done) => {
-    // 用户名与密码均使用恒定时间比较；先各自求值再判断，避免短路造成的时序差异
-    const userOk = safeEqual(username, USERNAME)
-    const passOk = safeEqual(password, PASSWORD)
-    if (userOk && passOk) done()
-    else done(new Error('Unauthorized'))
-  },
-  authenticate: { realm: 'ssl-checker' }
+fastify.get('/login', (req, reply) => {
+  if (isAuthenticated(req)) return reply.redirect('/')
+  return sendHtmlFile(reply, LOGIN_FILE, 'Failed to read login.html')
 })
 
-fastify.after(() => {
-  fastify.addHook('onRequest', fastify.basicAuth)
+fastify.post('/api/login', (req, reply) => {
+  const username = req.body && req.body.username
+  const password = req.body && req.body.password
 
-  fastify.get('/', (req, reply) => {
-    try {
-      reply.type('text/html')
-      return fs.readFileSync(INDEX_FILE)
-    } catch (err) {
-      reply.code(500)
-      return { code: -1, msg: 'Failed to read index.html' }
-    }
-  })
+  // 用户名与密码均使用恒定时间比较；先各自求值再判断，避免短路造成的时序差异
+  const userOk = safeEqual(username, USERNAME)
+  const passOk = safeEqual(password, PASSWORD)
+  if (!userOk || !passOk) {
+    reply.code(401)
+    return { code: -1, msg: '用户名或密码错误' }
+  }
 
-  fastify.get('/api/config', (req, reply) => {
-    try {
-      const configData = fs.readFileSync(CONFIG_FILE, 'utf8')
-      return { code: 1, result: configData }
-    } catch (err) {
-      // 配置文件不存在时返回空内容而非报错，便于首次使用
-      if (err.code === 'ENOENT') return { code: 1, result: '' }
-      reply.code(500)
-      return { code: -1, msg: 'Failed to read config' }
-    }
-  })
+  reply.header('Set-Cookie', serializeSessionCookie(createSessionToken(), SESSION_TTL_SECONDS))
+  return { code: 1 }
+})
 
-  fastify.post('/api/config', (req, reply) => {
-    const data = req.body && req.body.data
-    if (typeof data !== 'string' || !data.trim()) {
-      reply.code(400)
-      return { code: -2, msg: '内容为空' }
-    }
-    try {
-      // 原子写入配置文件
-      const tmp = `${CONFIG_FILE}.${process.pid}.tmp`
-      fs.writeFileSync(tmp, data, 'utf8')
-      fs.renameSync(tmp, CONFIG_FILE)
-      return { code: 1 }
-    } catch (err) {
-      reply.code(500)
-      return { code: -1, msg: '写入文件异常' }
-    }
-  })
+fastify.post('/api/logout', (req, reply) => {
+  reply.header('Set-Cookie', serializeSessionCookie('', 0))
+  return { code: 1 }
+})
 
-  fastify.get('/api/checkerSSLCertificate', async (req, reply) => {
-    const host = req.query.host
-    if (!host || !validateHost(host)) {
-      reply.code(400)
-      return { code: -2, msg: 'Host is required or invalid' }
-    }
+fastify.get('/', (req, reply) => {
+  if (!isAuthenticated(req)) return reply.redirect('/login')
+  return sendHtmlFile(reply, INDEX_FILE, 'Failed to read index.html')
+})
 
-    let port
-    try {
-      port = normalizePort(req.query.port)
-    } catch (err) {
-      reply.code(400)
-      return { code: -2, msg: err.message }
-    }
+fastify.get('/api/config', { preHandler: requireAuth }, (req, reply) => {
+  try {
+    const configData = fs.readFileSync(CONFIG_FILE, 'utf8')
+    return { code: 1, result: configData }
+  } catch (err) {
+    // 配置文件不存在时返回空内容而非报错，便于首次使用
+    if (err.code === 'ENOENT') return { code: 1, result: '' }
+    reply.code(500)
+    return { code: -1, msg: 'Failed to read config' }
+  }
+})
 
-    try {
-      const result = await cachedCheckerSSLCertificate(host.trim(), port)
-      return { code: 1, msg: 'ok', result }
-    } catch (err) {
-      return { code: -1, msg: err.message }
-    }
-  })
+fastify.post('/api/config', { preHandler: requireAuth }, (req, reply) => {
+  const data = req.body && req.body.data
+  if (typeof data !== 'string' || !data.trim()) {
+    reply.code(400)
+    return { code: -2, msg: '内容为空' }
+  }
+  try {
+    // 原子写入配置文件
+    const tmp = `${CONFIG_FILE}.${process.pid}.tmp`
+    fs.writeFileSync(tmp, data, 'utf8')
+    fs.renameSync(tmp, CONFIG_FILE)
+    return { code: 1 }
+  } catch (err) {
+    reply.code(500)
+    return { code: -1, msg: '写入文件异常' }
+  }
+})
 
-  fastify.post('/api/testSMS', async (req, reply) => {
-    const phones = req.body && req.body.phones
-    if (!Array.isArray(phones) || phones.length === 0) {
-      reply.code(400)
-      return { code: -2, msg: '手机号不能为空' }
-    }
-    try {
-      const result = await sendSMS(phones, { host: 'test', day: 0 })
-      return { code: 1, result }
-    } catch (err) {
-      return { code: -1, msg: err.message }
-    }
-  })
+fastify.get('/api/checkerSSLCertificate', { preHandler: requireAuth }, async (req, reply) => {
+  const host = req.query.host
+  if (!host || !validateHost(host)) {
+    reply.code(400)
+    return { code: -2, msg: 'Host is required or invalid' }
+  }
+
+  let port
+  try {
+    port = normalizePort(req.query.port)
+  } catch (err) {
+    reply.code(400)
+    return { code: -2, msg: err.message }
+  }
+
+  try {
+    const result = await cachedCheckerSSLCertificate(host.trim(), port)
+    return { code: 1, msg: 'ok', result }
+  } catch (err) {
+    return { code: -1, msg: err.message }
+  }
+})
+
+fastify.post('/api/testSMS', { preHandler: requireAuth }, async (req, reply) => {
+  const phones = req.body && req.body.phones
+  if (!Array.isArray(phones) || phones.length === 0) {
+    reply.code(400)
+    return { code: -2, msg: '手机号不能为空' }
+  }
+  try {
+    const result = await sendSMS(phones, { host: 'test', day: 0 })
+    return { code: 1, result }
+  } catch (err) {
+    return { code: -1, msg: err.message }
+  }
 })
 
 // ===== 定时巡检 =====

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start": "node main.js"
   },
   "dependencies": {
-    "@fastify/basic-auth": "^5.1.1",
     "axios": "^1.6.2",
     "dotenv": "^16.4.5",
     "fastify": "^4.24.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@fastify/basic-auth':
-        specifier: ^5.1.1
-        version: 5.1.1
       axios:
         specifier: ^1.6.2
         version: 1.10.0
@@ -38,9 +35,6 @@ packages:
 
   '@fastify/ajv-compiler@3.6.0':
     resolution: {integrity: sha512-LwdXQJjmMD+GwLOkP7TVC68qa+pSSogeWWmznRJ/coyTcfe9qA05AHFSe1eZFwK6q+xVRpChnvFUkf1iYaSZsQ==}
-
-  '@fastify/basic-auth@5.1.1':
-    resolution: {integrity: sha512-L4b7EK5LKZnV6fdH1+rQbjhkKGXjCfiKJ0JkdGHZQPBMHMiXDZF8xbZsCakWGf9c7jDXJicP3FPcIXUPBkuSeQ==}
 
   '@fastify/error@3.4.1':
     resolution: {integrity: sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ==}
@@ -161,9 +155,6 @@ packages:
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
-
-  fastify-plugin@4.5.1:
-    resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
 
   fastify@4.29.1:
     resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
@@ -379,11 +370,6 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       fast-uri: 2.4.0
 
-  '@fastify/basic-auth@5.1.1':
-    dependencies:
-      '@fastify/error': 3.4.1
-      fastify-plugin: 4.5.1
-
   '@fastify/error@3.4.1': {}
 
   '@fastify/fast-json-stringify-compiler@4.3.0':
@@ -502,8 +488,6 @@ snapshots:
   fast-uri@2.4.0: {}
 
   fast-uri@3.0.6: {}
-
-  fastify-plugin@4.5.1: {}
 
   fastify@4.29.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the global Basic Auth hook with a normal login page and signed httpOnly session cookie.
- Add logout and session-expiry handling in the existing management UI.
- Remove the unused basic-auth dependency and update deployment/auth documentation.

## Validation
- `node --check main.js` using the bundled Node runtime
- Parsed inline scripts in `index.html` and `login.html`
- `pnpm install --frozen-lockfile`
- `git diff --check`
- Verified the deployed Blog server flow: unauthenticated redirect, login, authenticated config access, logout, and post-logout 401.