### PR TITLE
Improve SSL certificate checks and errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@
   - `/api/config` – 获取或更新 `config.txt` 内容
   - `/api/checkerSSLCertificate` – 查询指定域名和端口的证书信息
 - 使用 **node-schedule** 每日检查 `config.txt` 中的域名
-- 通过 Node 的 `https` 模块获取证书并缓存到 `ssl_cache.json`
+- 通过 Node 的 `tls` 模块直接握手获取证书并缓存到 `ssl_cache.json`
 - 当证书距离过期不足三天时，触发 `sendSMS()` 发送提醒
 
 ### 短信发送模块 (`sendSMS.js`)
@@ -31,11 +31,11 @@
 - **凭证与会话比较**：登录凭证与会话签名使用 `crypto.timingSafeEqual` 恒定时间比较，规避时序侧信道
 - **会话保护**：登录成功后下发 httpOnly、SameSite=Lax 的签名 Cookie，过期或签名非法时拒绝访问受保护接口
 - **缓存**：内存优先 + 临时文件 `rename` 原子落盘，合并并发写入，规避读改写丢失与文件损坏
-- **输入校验**：API 对 host/port 做合法性校验
+- **输入校验与错误提示**：API 统一解析域名、URL、端口和注释，并将 DNS、超时、连接拒绝、非 TLS 服务等底层错误归一化为可操作提示
 - **优雅退出**：`SIGINT`/`SIGTERM` 时取消定时任务、落盘缓存、关闭服务器
 
 ### 配置文件 (`config.txt`)
-- 文本格式，每行 `域名[:端口]|手机号1,手机号2`
+- 文本格式，每行 `域名[:端口]|手机号1,手机号2`，手机号可为空；未配置手机号时仍会检测，只跳过短信发送
 - 支持使用 `//` 添加注释
 
 ### 前端页面 (`login.html`、`index.html`)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 1. 以简单的 js 脚本在 node.js 平台实现程序，利用现成的[node-schedule](https://github.com/node-schedule/node-schedule)库实现定时任务。
 2. 通过`axios`调用第三方接口实现短信发送，参数为`手机号数组`+`域名`+`即将过期天数/-过期天数`。
 3. 通过 HTML + JS 实现通知列表的可视化维护，通过登录页和签名会话 Cookie 进行身份认证。需要一个 Web 服务器实现服务器端向客户端输出 HTML 数据和 HTTP API，选择方便快捷的`fastify`。
-4. 通过 Node.js 的[https](https://nodejs.org/api/https.html)相关 API 实现对证书信息的获取。
+4. 通过 Node.js 的[tls](https://nodejs.org/api/tls.html)相关 API 直接进行 TLS 握手并获取证书信息。
 
 ## 实现
 
@@ -28,27 +28,23 @@ yarn add node-schedule axios fastify
 获取某个域名的 SSL 证书信息：
 
 ```javascript
-const https = require('https')
+const tls = require('tls')
 
-const req = https.request(
+const socket = tls.connect(
   {
     host: 'www.wyr.me',
     port: 443,
-    method: 'GET',
+    servername: 'www.wyr.me',
     rejectUnauthorized: false,
-    agent: new https.Agent({
-      maxCachedSessions: 0,
-    }),
   },
-  (res) => {
-    console.log(res.connection.getPeerCertificate())
-  }
+  () => {
+    console.log(socket.getPeerCertificate())
+    socket.end()
+  },
 )
-
-req.end()
 ```
 
-其中，`agent: new https.Agent({ maxCachedSessions: 0 })`是必须的，否则第二次请求的时候将无法获得证书信息。
+直接通过 TLS 握手获取证书，不依赖目标站点是否能正常返回 HTTP 响应，也能更准确地区分 DNS 解析失败、连接超时、端口拒绝连接、非 TLS 服务等错误。
 
 短信模板：
 

--- a/index.html
+++ b/index.html
@@ -369,6 +369,30 @@
       border: 1px solid #f5c6cb;
     }
 
+    .target-cell {
+      font-weight: 600;
+      color: #212529;
+      word-break: break-all;
+    }
+
+    .error-text {
+      color: #dc3545;
+      font-weight: 600;
+      line-height: 1.5;
+    }
+
+    .error-detail {
+      margin-top: 4px;
+      color: #6c757d;
+      font-size: 12px;
+      line-height: 1.45;
+      word-break: break-word;
+    }
+
+    .muted-text {
+      color: #6c757d;
+    }
+
     .section-title {
       margin-bottom: 20px;
       color: #495057;
@@ -543,21 +567,122 @@
       })
     }
 
-    const checkerSSLCertificate = (host, port = 443) => {
-      return new Promise((resolve, reject) => {
-        if (!port || isNaN(parseFloat(port)) || !isFinite(port)) {
-          reject(new Error('Invalid host or port'))
-        }
+    const escapeHtml = value => String(value === undefined || value === null ? '' : value).replace(/[&<>"']/g, char => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    })[char])
 
-        apiFetch(`/api/checkerSSLCertificate?host=${encodeURIComponent(host)}&port=${encodeURIComponent(port)}`, {
-          method: "GET",
-          // mode: 'cors',
-        }).then(response => response.json()).then(json => {
-          resolve(json)
-        }).catch(error => reject(error))
-      })
+    const stripInlineComment = line => {
+      const trimmed = String(line || '').trim()
+      if (trimmed.startsWith('//')) return ''
+
+      const match = trimmed.match(/\s+\/\//)
+      if (!match) return trimmed
+      return trimmed.slice(0, match.index).trim()
     }
 
+    const normalizePortInput = (value, fallback = 443) => {
+      if (value === undefined || value === null || value === '') return fallback
+
+      const raw = String(value).trim()
+      if (!/^\d+$/.test(raw)) {
+        throw new Error(`端口格式不正确：${raw}。请输入 1-65535 之间的整数。`)
+      }
+
+      const port = Number(raw)
+      if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`端口超出范围：${raw}。请输入 1-65535 之间的整数。`)
+      }
+      return port
+    }
+
+    const normalizeTargetInput = targetText => {
+      const raw = String(targetText || '').trim()
+      if (!raw) throw new Error('目标地址不能为空。请输入域名或 IP，例如 example.com 或 example.com:443。')
+
+      const bracketMatch = raw.match(/^\[([^\]]+)](?::(.+))?$/)
+      if (bracketMatch) {
+        return {
+          host: bracketMatch[1].trim(),
+          port: normalizePortInput(bracketMatch[2])
+        }
+      }
+
+      const hasProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+      const hasPathLikePart = /[/?#]/.test(raw)
+      if (hasProtocol || hasPathLikePart) {
+        let parsed
+        try {
+          parsed = new URL(hasProtocol ? raw : `https://${raw}`)
+        } catch (err) {
+          throw new Error(`目标地址格式不正确：${raw}。请输入域名、域名:端口 或 https:// 域名。`)
+        }
+
+        if (parsed.protocol && parsed.protocol !== 'https:') {
+          throw new Error(`暂不支持 ${parsed.protocol} 地址。SSL 检测目标应为 HTTPS/TLS 服务。`)
+        }
+
+        return {
+          host: parsed.hostname.replace(/^\[|\]$/g, ''),
+          port: normalizePortInput(parsed.port)
+        }
+      }
+
+      const colonCount = (raw.match(/:/g) || []).length
+      let host = raw
+      let port = 443
+      if (colonCount === 1) {
+        const parts = raw.split(':')
+        host = parts[0]
+        port = normalizePortInput(parts[1])
+      }
+
+      host = host.trim().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+      if (!host || /[\s\\]/.test(host)) {
+        throw new Error(`域名格式不正确：${raw}。请检查是否包含空格、路径或非法字符。`)
+      }
+
+      return { host, port }
+    }
+
+    const formatTargetLabel = target => {
+      const host = target.host.includes(':') ? `[${target.host}]` : target.host
+      return target.port === 443 ? host : `${host}:${target.port}`
+    }
+
+    const formatDate = value => {
+      const date = new Date(value)
+      if (Number.isNaN(date.getTime())) return escapeHtml(value)
+      return date.Format('yyyy-MM-dd HH:mm:ss')
+    }
+
+    const renderErrorRow = (tr, targetLabel, message, phoneList, detail = '', badge = '失败') => {
+      tr.innerHTML = `
+        <td class="target-cell">${escapeHtml(targetLabel)}</td>
+        <td colspan="2">
+          <div class="error-text">${escapeHtml(message)}</div>
+          ${detail ? `<div class="error-detail">技术细节：${escapeHtml(detail)}</div>` : ''}
+        </td>
+        <td><span class="status-badge status-error">${escapeHtml(badge)}</span></td>
+        <td>${escapeHtml(phoneList.join(', ')) || '<span class="muted-text">未配置</span>'}</td>
+      `
+    }
+
+    const checkerSSLCertificate = target => {
+      return apiFetch(`/api/checkerSSLCertificate?host=${encodeURIComponent(target.host)}&port=${encodeURIComponent(target.port)}`, {
+        method: "GET",
+        // mode: 'cors',
+      }).then(async response => {
+        const json = await response.json().catch(() => ({
+          code: -1,
+          msg: `服务器返回了非 JSON 响应（HTTP ${response.status}）`
+        }))
+        return json
+      })
+    }
 
     const getConfig = () => {
       apiFetch('/api/config', {
@@ -574,37 +699,67 @@
         const progressBar = document.getElementById('progressBar')
         const tbody = document.getElementById('tbody')
         tbody.innerHTML = ''
+        progressBar.style.width = '0%'
         let total = 0
         let finished = 0
+        let successCount = 0
+        let failureCount = 0
+        let invalidCount = 0
         const domains = []
 
-        for (const lineRaw of lines) {
-          let line = lineRaw
-          if (line.trim().includes('//')) {
-            line = line.split('//')[0]
+        lines.forEach((lineRaw, index) => {
+          const line = stripInlineComment(lineRaw)
+          if (!line.trim()) return
+
+          const separatorIndex = line.indexOf('|')
+          const targetText = separatorIndex === -1 ? line : line.slice(0, separatorIndex).trim()
+          const phoneText = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1).trim()
+          const phoneList = phoneText ? phoneText.split(',').map(p => p.trim()).filter(p => p) : []
+
+          let target
+          let targetLabel
+          try {
+            target = normalizeTargetInput(targetText)
+            targetLabel = formatTargetLabel(target)
+          } catch (err) {
+            invalidCount++
+            const tr = document.createElement('tr')
+            renderErrorRow(
+              tr,
+              `第 ${index + 1} 行`,
+              `配置格式错误：${err.message}`,
+              phoneList,
+              lineRaw,
+              '配置错误'
+            )
+            tbody.appendChild(tr)
+            return
           }
-          if (!line.trim()) continue
 
-          const [hostStr, phones] = line.split('|')
-          if (!hostStr || !hostStr.trim()) continue
-
-          const phoneList = phones && phones.split ? phones.split(',').map(p => p.trim()) : []
-          const [host, port] = hostStr.trim().split(':')
           total++
           const rowId = 'row-' + total
           const tr = document.createElement('tr')
           tr.id = rowId
           tr.innerHTML = `
-            <td>${host}${port && port !== '443' ? ':' + port : ''}</td>
+            <td class="target-cell">${escapeHtml(targetLabel)}</td>
             <td colspan="3"><span class="loading">检测中</span></td>
-            <td>${phoneList.join(', ')}</td>
+            <td>${escapeHtml(phoneList.join(', ')) || '<span class="muted-text">未配置</span>'}</td>
           `
           tbody.appendChild(tr)
-          domains.push({ host, port, phoneList, rowId })
-        }
+          domains.push({ target, targetLabel, phoneList, rowId })
+        })
 
         if (total === 0) {
-          progressText.textContent = '未检测到域名'
+          progressText.textContent = invalidCount > 0
+            ? `没有可检测的域名，已发现 ${invalidCount} 行配置问题`
+            : '未检测到域名'
+          if (invalidCount === 0) {
+            tbody.innerHTML = `
+              <tr>
+                <td colspan="5" class="empty-state">暂无配置</td>
+              </tr>
+            `
+          }
           return
         }
 
@@ -615,43 +770,37 @@
           progressText.textContent = `检测进度：${finished}/${total}`
           progressBar.style.width = (finished / total * 100) + '%'
           if (finished === total) {
-            progressText.textContent = '检测完成'
+            const suffix = invalidCount > 0 ? `，配置问题 ${invalidCount} 行` : ''
+            progressText.textContent = `检测完成：成功 ${successCount} 个，失败 ${failureCount} 个${suffix}`
           }
         }
 
-        domains.forEach(({ host, port, phoneList, rowId }) => {
-          checkerSSLCertificate(host, port).then(({ code, msg, result }) => {
+        domains.forEach(({ target, targetLabel, phoneList, rowId }) => {
+          checkerSSLCertificate(target).then(({ code, msg, result, error }) => {
             const tr = document.getElementById(rowId)
             if (code === 1) {
               const { valid_from, valid_to, days } = result
               let statusClass = 'status-success'
               if (days <= 7) statusClass = 'status-error'
               else if (days <= 30) statusClass = 'status-warning'
+              successCount++
 
               tr.innerHTML = `
-                <td>${host}${port && port !== '443' ? ':' + port : ''}</td>
-                <td>${new Date(valid_from).Format('yyyy-MM-dd HH:mm:ss')}</td>
-                <td>${new Date(valid_to).Format('yyyy-MM-dd HH:mm:ss')}</td>
+                <td class="target-cell">${escapeHtml(targetLabel)}</td>
+                <td>${formatDate(valid_from)}</td>
+                <td>${formatDate(valid_to)}</td>
                 <td><span class="status-badge ${statusClass}">${days} 天</span></td>
-                <td>${phoneList.join(', ')}</td>
+                <td>${escapeHtml(phoneList.join(', ')) || '<span class="muted-text">未配置</span>'}</td>
               `
             } else {
-              tr.innerHTML = `
-                <td>${host}${port && port !== '443' ? ':' + port : ''}</td>
-                <td colspan="2"><span style="color: #dc3545;">请求失败：${msg}</span></td>
-                <td><span class="status-badge status-error">失败</span></td>
-                <td>${phoneList.join(', ')}</td>
-              `
+              failureCount++
+              renderErrorRow(tr, targetLabel, msg || '检测失败', phoneList, error && error.detail)
             }
           }).catch(err => {
             if (err.message === SESSION_EXPIRED) return
+            failureCount++
             const tr = document.getElementById(rowId)
-            tr.innerHTML = `
-              <td>${host}${port && port !== '443' ? ':' + port : ''}</td>
-              <td colspan="2"><span style="color: #dc3545;">请求失败：网络错误</span></td>
-              <td><span class="status-badge status-error">失败</span></td>
-              <td>${phoneList.join(', ')}</td>
-            `
+            renderErrorRow(tr, targetLabel, '请求失败：网络错误，请检查服务端是否可用。', phoneList, err.message)
           }).finally(updateProgress)
         })
       }).catch(err => {

--- a/main.js
+++ b/main.js
@@ -3,8 +3,10 @@ require('dotenv').config()
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const https = require('https')
+const tls = require('tls')
+const net = require('net')
 const crypto = require('crypto')
+const { domainToASCII } = require('url')
 const fastify = require('fastify')({ logger: true })
 const sendSMS = require('./sendSMS')
 
@@ -32,6 +34,7 @@ const LOGIN_FILE = path.join(__dirname, 'login.html')
 const CACHE_EXPIRATION_SUCCESS = 5 * 60 * 1000 // 成功结果缓存 5 分钟
 const CACHE_EXPIRATION_ERROR = 1 * 60 * 1000 // 错误结果缓存 1 分钟
 const SESSION_COOKIE_NAME = 'ssl_checker_session'
+const DAY_MS = 24 * 60 * 60 * 1000
 
 // ===== 启动前置校验：缺少鉴权凭证则拒绝启动（避免裸奔） =====
 if (!USERNAME || !PASSWORD) {
@@ -155,103 +158,346 @@ function sendHtmlFile (reply, filePath, errorMsg) {
   }
 }
 
-// 校验并归一化端口
+function createCheckError (message, options = {}) {
+  const error = new Error(message)
+  error.code = options.code || 'CHECK_FAILED'
+  error.detail = options.detail
+  error.retryable = options.retryable !== false
+  return error
+}
+
+function stripInlineComment (line) {
+  const trimmed = String(line || '').trim()
+  if (trimmed.startsWith('//')) return ''
+
+  const match = trimmed.match(/\s+\/\//)
+  if (!match) return trimmed
+  return trimmed.slice(0, match.index).trim()
+}
+
+// 校验并归一化端口。parseInt 会接受 "443abc"，这里必须严格拒绝。
 function normalizePort (value, fallback = 443) {
   if (value === undefined || value === null || value === '') return fallback
-  const port = parseInt(value, 10)
+
+  const raw = String(value).trim()
+  if (!/^\d+$/.test(raw)) {
+    throw createCheckError(`端口格式不正确：${raw}。请输入 1-65535 之间的整数。`, {
+      code: 'INVALID_PORT',
+      retryable: false
+    })
+  }
+
+  const port = Number(raw)
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    throw new Error(`Invalid port: ${value}`)
+    throw createCheckError(`端口超出范围：${raw}。请输入 1-65535 之间的整数。`, {
+      code: 'INVALID_PORT',
+      retryable: false
+    })
   }
   return port
 }
 
-// 基础的主机名/IP 合法性校验，拒绝明显非法或注入字符
-function validateHost (host) {
-  if (typeof host !== 'string') return false
-  const trimmed = host.trim()
-  if (!trimmed || trimmed.length > 253) return false
-  // 仅允许域名/IP 允许出现的字符
-  return /^[a-zA-Z0-9.\-_:[\]]+$/.test(trimmed)
+function normalizeHost (value) {
+  const raw = String(value || '').trim().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+  if (!raw) {
+    throw createCheckError('目标地址不能为空。请输入域名或 IP，例如 example.com 或 example.com:443。', {
+      code: 'INVALID_HOST',
+      retryable: false
+    })
+  }
+
+  if (net.isIP(raw)) return raw
+
+  const asciiHost = domainToASCII(raw).toLowerCase()
+  if (!asciiHost || asciiHost.length > 253) {
+    throw createCheckError(`域名格式不正确：${raw}。`, {
+      code: 'INVALID_HOST',
+      retryable: false
+    })
+  }
+
+  const labels = asciiHost.split('.')
+  const isValidDomain = labels.every(label => (
+    label.length > 0 &&
+    label.length <= 63 &&
+    /^[a-z0-9-]+$/.test(label) &&
+    !label.startsWith('-') &&
+    !label.endsWith('-')
+  ))
+
+  if (!isValidDomain) {
+    throw createCheckError(`域名格式不正确：${raw}。请检查是否包含空格、路径或非法字符。`, {
+      code: 'INVALID_HOST',
+      retryable: false
+    })
+  }
+
+  return asciiHost
+}
+
+function normalizeTarget (value, fallbackPort = 443) {
+  const raw = String(value || '').trim()
+  if (!raw) {
+    throw createCheckError('目标地址不能为空。请输入域名或 IP，例如 example.com 或 example.com:443。', {
+      code: 'INVALID_TARGET',
+      retryable: false
+    })
+  }
+
+  const bracketMatch = raw.match(/^\[([^\]]+)](?::(.+))?$/)
+  if (bracketMatch) {
+    return {
+      host: normalizeHost(bracketMatch[1]),
+      port: normalizePort(bracketMatch[2], fallbackPort)
+    }
+  }
+
+  if (net.isIP(raw)) {
+    return {
+      host: normalizeHost(raw),
+      port: fallbackPort
+    }
+  }
+
+  const hasProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+  const hasPathLikePart = /[/?#]/.test(raw)
+  if (hasProtocol || hasPathLikePart) {
+    let parsed
+    try {
+      parsed = new URL(hasProtocol ? raw : `https://${raw}`)
+    } catch (err) {
+      throw createCheckError(`目标地址格式不正确：${raw}。请输入域名、域名:端口 或 https:// 域名。`, {
+        code: 'INVALID_TARGET',
+        retryable: false,
+        detail: err.message
+      })
+    }
+
+    if (parsed.protocol && parsed.protocol !== 'https:') {
+      throw createCheckError(`暂不支持 ${parsed.protocol} 地址。SSL 检测目标应为 HTTPS/TLS 服务。`, {
+        code: 'UNSUPPORTED_PROTOCOL',
+        retryable: false
+      })
+    }
+
+    return {
+      host: normalizeHost(parsed.hostname),
+      port: normalizePort(parsed.port, fallbackPort)
+    }
+  }
+
+  const colonCount = (raw.match(/:/g) || []).length
+  if (colonCount > 1) {
+    return {
+      host: normalizeHost(raw),
+      port: fallbackPort
+    }
+  }
+
+  if (colonCount === 1) {
+    const [host, port] = raw.split(':')
+    return {
+      host: normalizeHost(host),
+      port: normalizePort(port, fallbackPort)
+    }
+  }
+
+  return {
+    host: normalizeHost(raw),
+    port: fallbackPort
+  }
+}
+
+function formatTarget (host, port) {
+  const displayHost = net.isIP(host) === 6 ? `[${host}]` : host
+  return `${displayHost}:${port}`
+}
+
+function getTLSServerName (host) {
+  return net.isIP(host) ? undefined : host
+}
+
+function normalizeCheckError (err, host, port) {
+  if (err && err.code && err.retryable !== undefined) return err
+
+  const detail = err && err.message ? err.message : String(err || 'unknown error')
+  const code = err && err.code
+  const lowerDetail = detail.toLowerCase()
+  const target = formatTarget(host, port)
+
+  if (code === 'ENOTFOUND') {
+    return createCheckError(`域名解析失败：${host}。请检查域名是否拼写正确，以及 DNS 记录是否存在。`, {
+      code: 'DNS_NOT_FOUND',
+      retryable: false,
+      detail
+    })
+  }
+
+  if (code === 'EAI_AGAIN') {
+    return createCheckError(`DNS 查询暂时失败：${host}。请稍后重试，或检查服务器 DNS 网络。`, {
+      code: 'DNS_TEMPORARY_FAILURE',
+      detail
+    })
+  }
+
+  if (code === 'ECONNREFUSED') {
+    return createCheckError(`无法连接 ${target}：目标端口拒绝连接。请确认 HTTPS/TLS 服务正在监听该端口。`, {
+      code: 'CONNECTION_REFUSED',
+      retryable: false,
+      detail
+    })
+  }
+
+  if (code === 'ETIMEDOUT' || code === 'TIMEOUT') {
+    return createCheckError(`连接 ${target} 超时。请确认目标网络可达，或调大 REQUEST_TIMEOUT。`, {
+      code: 'CHECK_TIMEOUT',
+      detail
+    })
+  }
+
+  if (code === 'ECONNRESET') {
+    return createCheckError(`连接 ${target} 被目标服务器重置。请确认该端口提供 HTTPS/TLS 服务。`, {
+      code: 'CONNECTION_RESET',
+      detail
+    })
+  }
+
+  if (
+    code === 'EPROTO' ||
+    code === 'ERR_SSL_WRONG_VERSION_NUMBER' ||
+    lowerDetail.includes('wrong version number') ||
+    lowerDetail.includes('unknown protocol') ||
+    lowerDetail.includes('packet length too long')
+  ) {
+    return createCheckError(`目标 ${target} 未返回有效的 TLS 证书。请确认端口不是普通 HTTP、SSH 或其他非 HTTPS 服务。`, {
+      code: 'NON_TLS_SERVICE',
+      retryable: false,
+      detail
+    })
+  }
+
+  return createCheckError(`检测 ${target} 失败：${detail}`, {
+    code: code || 'CHECK_FAILED',
+    detail
+  })
+}
+
+function parseCertificateDate (value, label) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw createCheckError(`证书${label}时间无法解析：${value}`, {
+      code: 'INVALID_CERT_DATE',
+      retryable: false
+    })
+  }
+  return date
 }
 
 async function checkerSSLCertificate (host, port = 443) {
   return new Promise((resolve, reject) => {
     let settled = false
+    let socket
     const finish = (fn, arg) => {
       if (settled) return
       settled = true
       fn(arg)
     }
 
-    let req
     try {
-      req = https.request({
+      socket = tls.connect({
         host,
         port,
-        method: 'GET',
+        servername: getTLSServerName(host),
         rejectUnauthorized: false,
-        agent: new https.Agent({
-          maxCachedSessions: 0,
-          timeout: REQUEST_TIMEOUT
-        }),
         timeout: REQUEST_TIMEOUT
-      }, function (res) {
+      }, () => {
         try {
-          const certificateInfo = res.socket.getPeerCertificate()
-          // 消费并丢弃响应体，避免 socket 挂起
-          res.resume()
-
-          if (!certificateInfo || !certificateInfo.valid_from || !certificateInfo.valid_to) {
-            return finish(reject, new Error('No certificate information available'))
+          const certificateInfo = socket.getPeerCertificate()
+          if (!certificateInfo || Object.keys(certificateInfo).length === 0) {
+            throw createCheckError(`无法获取 ${formatTarget(host, port)} 的证书信息。目标可能未提供 TLS 证书。`, {
+              code: 'NO_CERTIFICATE',
+              retryable: false
+            })
           }
 
-          const expires = new Date(certificateInfo.valid_to)
-          const now = new Date()
-          const timeDiff = expires - now
-
-          if (isNaN(timeDiff)) {
-            return finish(reject, new Error('Invalid certificate date'))
+          if (!certificateInfo.valid_from || !certificateInfo.valid_to) {
+            throw createCheckError(`证书信息不完整：缺少起效时间或到期时间。`, {
+              code: 'INCOMPLETE_CERTIFICATE',
+              retryable: false
+            })
           }
 
-          const days = Math.floor(timeDiff / (24 * 60 * 60 * 1000))
+          parseCertificateDate(certificateInfo.valid_from, '起效')
+          const validTo = parseCertificateDate(certificateInfo.valid_to, '到期')
+          const days = Math.floor((validTo.getTime() - Date.now()) / DAY_MS)
 
           finish(resolve, {
             valid_from: certificateInfo.valid_from,
             valid_to: certificateInfo.valid_to,
-            days
+            days,
+            expired: validTo.getTime() < Date.now(),
+            issuer: certificateInfo.issuer,
+            subject: certificateInfo.subject,
+            fingerprint256: certificateInfo.fingerprint256
           })
         } catch (err) {
-          finish(reject, err)
+          finish(reject, normalizeCheckError(err, host, port))
+        } finally {
+          socket.end()
         }
       })
     } catch (err) {
-      return finish(reject, err)
+      return finish(reject, normalizeCheckError(err, host, port))
     }
 
-    req.on('timeout', () => {
-      req.destroy()
-      finish(reject, new Error('Request timed out'))
-    })
-
-    req.on('error', err => {
+    socket.setTimeout(REQUEST_TIMEOUT, () => {
+      const err = createCheckError(`连接 ${formatTarget(host, port)} 超时。请确认目标网络可达，或调大 REQUEST_TIMEOUT。`, {
+        code: 'CHECK_TIMEOUT',
+        detail: `socket timeout after ${REQUEST_TIMEOUT}ms`
+      })
+      socket.destroy()
       finish(reject, err)
     })
 
-    req.end()
+    socket.once('error', err => {
+      finish(reject, normalizeCheckError(err, host, port))
+    })
   })
 }
 
 async function retryRequest (host, port = 443, retries = MAX_RETRIES) {
   let lastErr
-  for (let attempt = 1; attempt <= retries; attempt++) {
+  let attemptsUsed = 0
+  const totalRetries = Number.isInteger(retries) && retries > 0 ? retries : 1
+
+  for (let attempt = 1; attempt <= totalRetries; attempt++) {
+    attemptsUsed = attempt
     try {
       return await checkerSSLCertificate(host, port)
     } catch (err) {
-      lastErr = err
-      fastify.log.warn(`Attempt ${attempt}/${retries} failed for ${host}:${port} - ${err.message}`)
+      lastErr = normalizeCheckError(err, host, port)
+      const detail = lastErr.detail ? ` (${lastErr.detail})` : ''
+      fastify.log.warn(`Attempt ${attempt}/${totalRetries} failed for ${formatTarget(host, port)} - ${lastErr.message}${detail}`)
+      if (lastErr.retryable === false) break
     }
   }
-  throw new Error(`Failed after ${retries} attempts: ${lastErr ? lastErr.message : 'unknown error'}`)
+
+  if (!lastErr) {
+    throw createCheckError(`检测 ${formatTarget(host, port)} 失败：未知错误`, {
+      code: 'CHECK_FAILED',
+      retryable: false
+    })
+  }
+
+  if (attemptsUsed > 1 && lastErr.retryable !== false) {
+    throw createCheckError(`连续检测 ${attemptsUsed} 次均失败：${lastErr.message}`, {
+      code: lastErr.code,
+      detail: lastErr.detail,
+      retryable: false
+    })
+  }
+
+  throw lastErr
 }
 
 // ===== 缓存：内存优先 + 原子落盘，规避并发读改写丢失更新 =====
@@ -289,7 +535,7 @@ function scheduleCachePersist () {
 }
 
 async function cachedCheckerSSLCertificate (host, port = 443) {
-  const cacheKey = `${host}:${port}`
+  const cacheKey = formatTarget(host, port)
   const now = Date.now()
 
   const entry = cache[cacheKey]
@@ -300,7 +546,20 @@ async function cachedCheckerSSLCertificate (host, port = 443) {
 
     if (now - timestamp < expiration) {
       fastify.log.info(`Using cached ${isError ? 'error' : 'result'} for ${cacheKey}`)
-      if (isError) throw new Error(error)
+      if (isError) {
+        if (typeof error === 'string') {
+          throw createCheckError(error, {
+            code: 'CACHED_CHECK_FAILED',
+            retryable: false
+          })
+        }
+
+        throw createCheckError(error.message || '检测失败', {
+          code: error.code || 'CACHED_CHECK_FAILED',
+          detail: error.detail,
+          retryable: false
+        })
+      }
       return result
     }
     delete cache[cacheKey]
@@ -312,7 +571,14 @@ async function cachedCheckerSSLCertificate (host, port = 443) {
     scheduleCachePersist()
     return result
   } catch (err) {
-    cache[cacheKey] = { timestamp: now, error: err.message }
+    cache[cacheKey] = {
+      timestamp: now,
+      error: {
+        message: err.message,
+        code: err.code,
+        detail: err.detail
+      }
+    }
     scheduleCachePersist()
     throw err
   }
@@ -381,25 +647,36 @@ fastify.post('/api/config', { preHandler: requireAuth }, (req, reply) => {
 })
 
 fastify.get('/api/checkerSSLCertificate', { preHandler: requireAuth }, async (req, reply) => {
-  const host = req.query.host
-  if (!host || !validateHost(host)) {
-    reply.code(400)
-    return { code: -2, msg: 'Host is required or invalid' }
-  }
-
-  let port
+  let target
   try {
-    port = normalizePort(req.query.port)
+    target = normalizeTarget(req.query.host)
+    if (req.query.port !== undefined && req.query.port !== '') {
+      target.port = normalizePort(req.query.port)
+    }
   } catch (err) {
     reply.code(400)
-    return { code: -2, msg: err.message }
+    return {
+      code: -2,
+      msg: err.message,
+      error: {
+        code: err.code,
+        detail: err.detail
+      }
+    }
   }
 
   try {
-    const result = await cachedCheckerSSLCertificate(host.trim(), port)
-    return { code: 1, msg: 'ok', result }
+    const result = await cachedCheckerSSLCertificate(target.host, target.port)
+    return { code: 1, msg: 'ok', result, target }
   } catch (err) {
-    return { code: -1, msg: err.message }
+    return {
+      code: -1,
+      msg: err.message,
+      error: {
+        code: err.code,
+        detail: err.detail
+      }
+    }
   }
 })
 
@@ -420,25 +697,27 @@ fastify.post('/api/testSMS', { preHandler: requireAuth }, async (req, reply) => 
 // ===== 定时巡检 =====
 function parseConfigLines (raw) {
   const tasks = []
-  for (const lineRaw of raw.split('\n')) {
-    let line = lineRaw.trim()
-    if (line.includes('//')) line = line.split('//')[0].trim()
-    if (!line) continue
+  raw.split(/\r?\n/).forEach((lineRaw, index) => {
+    const line = stripInlineComment(lineRaw)
+    if (!line) return
 
-    const [hostStr, phones] = line.split('|')
-    if (!hostStr || !phones) {
-      fastify.log.warn(`Invalid line in config.txt: ${lineRaw}`)
-      continue
+    const separatorIndex = line.indexOf('|')
+    const targetText = separatorIndex === -1 ? line : line.slice(0, separatorIndex).trim()
+    const phoneText = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1).trim()
+
+    let target
+    try {
+      target = normalizeTarget(targetText)
+    } catch (err) {
+      fastify.log.warn(`Invalid config line ${index + 1}: ${err.message} Raw: ${lineRaw}`)
+      return
     }
 
-    const phoneList = phones.split(',').map(p => p.trim()).filter(Boolean)
-    const [host, port] = hostStr.trim().split(':')
-    if (!host || phoneList.length === 0) {
-      fastify.log.warn(`Invalid line in config.txt: ${lineRaw}`)
-      continue
-    }
-    tasks.push({ host: host.trim(), port, phoneList })
-  }
+    const phoneList = phoneText
+      ? phoneText.split(',').map(p => p.trim()).filter(Boolean)
+      : []
+    tasks.push({ ...target, phoneList, line: index + 1 })
+  })
   return tasks
 }
 
@@ -453,23 +732,28 @@ async function runScheduledCheck () {
 
   const entries = parseConfigLines(raw)
   await Promise.allSettled(entries.map(async ({ host, port, phoneList }) => {
-    const usePort = port ? parseInt(port, 10) : 443
+    const target = formatTarget(host, port)
     try {
-      const { days } = await cachedCheckerSSLCertificate(host, usePort)
+      const { days } = await cachedCheckerSSLCertificate(host, port)
       if (days < WARN_DAYS) {
-        fastify.log.warn(`SSL certificate for ${host} expires in ${days} days`)
+        fastify.log.warn(`SSL certificate for ${target} expires in ${days} days`)
+        if (phoneList.length === 0) {
+          fastify.log.warn(`No phone numbers configured for ${target}; skip SMS alert`)
+          return
+        }
+
         try {
           const smsResult = await sendSMS(phoneList, {
             host: host.replace(/\./g, '-').substring(0, 15),
             day: days
           })
-          fastify.log.info(`SMS sent for ${host}: ${JSON.stringify(smsResult)}`)
+          fastify.log.info(`SMS sent for ${target}: ${JSON.stringify(smsResult)}`)
         } catch (smsErr) {
-          fastify.log.error(`Failed to send SMS for ${host}: ${smsErr.message}`)
+          fastify.log.error(`Failed to send SMS for ${target}: ${smsErr.message}`)
         }
       }
     } catch (err) {
-      fastify.log.error(`Failed to check SSL for ${host}:${usePort} - ${err.message}`)
+      fastify.log.error(`Failed to check SSL for ${target} - ${err.message}`)
     }
   }))
 }


### PR DESCRIPTION
## Summary
- switch certificate detection from HTTPS GET requests to direct TLS handshakes
- normalize host, URL, port, and config parsing for API and scheduled checks
- return clearer Chinese error messages for DNS failures, timeouts, refused connections, non-TLS services, and invalid config
- surface config and check errors more clearly in the admin table

## Validation
- `node --check main.js`
- extracted `index.html` script syntax check with Node
- `git diff --check`
- deployed to Blog host and verified `ssl-checker` PM2 process, local `/login`, unauthenticated `/api/config`, and public `https://ssl.wyr.me/login`