### PR TITLE
Fix phone comment parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,6 +584,12 @@
       return trimmed.slice(0, match.index).trim()
     }
 
+    const stripPhoneComment = value => {
+      const text = String(value || '').trim()
+      const commentIndex = text.indexOf('//')
+      return commentIndex === -1 ? text : text.slice(0, commentIndex).trim()
+    }
+
     const normalizePortInput = (value, fallback = 443) => {
       if (value === undefined || value === null || value === '') return fallback
 
@@ -713,7 +719,7 @@
 
           const separatorIndex = line.indexOf('|')
           const targetText = separatorIndex === -1 ? line : line.slice(0, separatorIndex).trim()
-          const phoneText = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1).trim()
+          const phoneText = separatorIndex === -1 ? '' : stripPhoneComment(line.slice(separatorIndex + 1))
           const phoneList = phoneText ? phoneText.split(',').map(p => p.trim()).filter(p => p) : []
 
           let target

--- a/main.js
+++ b/main.js
@@ -177,6 +177,12 @@ function stripInlineComment (line) {
   return trimmed.slice(0, match.index).trim()
 }
 
+function stripPhoneComment (value) {
+  const text = String(value || '').trim()
+  const commentIndex = text.indexOf('//')
+  return commentIndex === -1 ? text : text.slice(0, commentIndex).trim()
+}
+
 // 校验并归一化端口。parseInt 会接受 "443abc"，这里必须严格拒绝。
 function normalizePort (value, fallback = 443) {
   if (value === undefined || value === null || value === '') return fallback
@@ -705,7 +711,7 @@ function parseConfigLines (raw) {
 
     const separatorIndex = line.indexOf('|')
     const targetText = separatorIndex === -1 ? line : line.slice(0, separatorIndex).trim()
-    const phoneText = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1).trim()
+    const phoneText = separatorIndex === -1 ? '' : stripPhoneComment(line.slice(separatorIndex + 1))
 
     let target
     try {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -18,6 +18,7 @@ www.example.com|13800138000, 13800138001
 api.example.com:8443|13900139000
 status.example.com
 bad.example.com:abc|13600136000
+https://ssl.example.com/path|15887150449//腾讯云跳转到博客
 `)
 
   assert.deepEqual(tasks, [
@@ -38,6 +39,12 @@ bad.example.com:abc|13600136000
       port: 443,
       phoneList: [],
       line: 4
+    },
+    {
+      host: 'ssl.example.com',
+      port: 443,
+      phoneList: ['15887150449'],
+      line: 6
     }
   ])
 })


### PR DESCRIPTION
## Summary
- strip `//` comments from the phone-number field before rendering the table
- apply the same parsing rule to scheduled notification recipients
- add coverage for `手机号//备注` while preserving `https://` target parsing

## Validation
- node --check main.js
- node --check sendSMS.js
- pnpm test
- in-app browser login/table check with `15887150449//腾讯云跳转到博客` rows